### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@
 ^codecov\.yml$
 ^\.github$
 ^vignettes/articles$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/birth-matrix.R
+++ b/R/birth-matrix.R
@@ -22,10 +22,12 @@
 #'
 #' @examples
 #' bbs_matrix_birth(c(0, 0, 0.2, 0, 0.25, 0)) %*% rep(100, 6)
-bbs_matrix_birth <- function(fecundity,
-                             female_recruit_stage = 1,
-                             male_recruit_stage = NULL,
-                             proportion_female = 0.5) {
+bbs_matrix_birth <- function(
+  fecundity,
+  female_recruit_stage = 1,
+  male_recruit_stage = NULL,
+  proportion_female = 0.5
+) {
   chk_numeric(fecundity)
   chk_gte(fecundity)
   chk_null_or(male_recruit_stage, vld = vld_whole_number)
@@ -57,10 +59,12 @@ bbs_matrix_birth <- function(fecundity,
 #' @examples
 #' fec <- bbs_fecundity(c(NA, 0.7), nyear = 3)
 #' bbs_matrix_birth_year(fec$eFecundity)
-bbs_matrix_birth_year <- function(fecundity,
-                                  female_recruit_stage = 1,
-                                  male_recruit_stage = NULL,
-                                  proportion_female = 0.5) {
+bbs_matrix_birth_year <- function(
+  fecundity,
+  female_recruit_stage = 1,
+  male_recruit_stage = NULL,
+  proportion_female = 0.5
+) {
   chk_is(fecundity, "matrix")
   chk_length(dim(fecundity), 2L)
 
@@ -69,7 +73,8 @@ bbs_matrix_birth_year <- function(fecundity,
   nstate <- dims[2]
   x <- array(0, dim = c(nstate, nstate, nyear))
   for (year in 1:nyear) {
-    x[, , year] <- bbs_matrix_birth(fecundity[year, ],
+    x[,, year] <- bbs_matrix_birth(
+      fecundity[year, ],
       female_recruit_stage = female_recruit_stage,
       male_recruit_stage = male_recruit_stage,
       proportion_female = proportion_female

--- a/R/birth.R
+++ b/R/birth.R
@@ -26,10 +26,12 @@
 #'
 #' @examples
 #' bbs_fecundity(c(NA, logit(0.4)), trend = c(NA, 0.1), annual_sd = c(NA, 0.05))
-bbs_fecundity <- function(intercept,
-                          trend = rep(0, length(intercept)),
-                          annual_sd = rep(0, length(intercept)),
-                          nyear = 10) {
+bbs_fecundity <- function(
+  intercept,
+  trend = rep(0, length(intercept)),
+  annual_sd = rep(0, length(intercept)),
+  nyear = 10
+) {
   chk_numeric(intercept)
   chk_numeric(trend)
   chk_length(trend, length(intercept))
@@ -81,10 +83,12 @@ bbs_fecundity <- function(intercept,
 #'
 #' @examples
 #' bbs_fecundity_caribou(0.4, trend = 0.1, annual_sd = 0.3)
-bbs_fecundity_caribou <- function(calves_per_adult_female,
-                                  trend = 0,
-                                  annual_sd = 0,
-                                  nyear = 10) {
+bbs_fecundity_caribou <- function(
+  calves_per_adult_female,
+  trend = 0,
+  annual_sd = 0,
+  nyear = 10
+) {
   chk_number(calves_per_adult_female)
   chk_gte(calves_per_adult_female)
   chk_number(trend)
@@ -96,9 +100,5 @@ bbs_fecundity_caribou <- function(calves_per_adult_female,
   trend <- c(0, 0, trend)
   annual_sd <- c(0, 0, annual_sd)
 
-  bbs_fecundity(intercept,
-    trend = trend,
-    annual_sd = annual_sd,
-    nyear = nyear
-  )
+  bbs_fecundity(intercept, trend = trend, annual_sd = annual_sd, nyear = nyear)
 }

--- a/R/chk.R
+++ b/R/chk.R
@@ -17,8 +17,11 @@
     return(invisible(x))
   }
   x_name <- deparse_backtick_chk(substitute(x))
-  abort_chk(x_name, "must be a valid array of fecundity rates.
-            See `bbs_survival_caribou()` and `bbs_survival()` for details.")
+  abort_chk(
+    x_name,
+    "must be a valid array of fecundity rates.
+            See `bbs_survival_caribou()` and `bbs_survival()` for details."
+  )
 }
 
 .chk_fecundity <- function(x) {
@@ -26,8 +29,11 @@
     return(invisible(x))
   }
   x_name <- deparse_backtick_chk(substitute(x))
-  abort_chk(x_name, "must be a valid array of fecundity rates.
-            See `bbs_fecundity_caribou()` and `bbs_fecundity()` for details.")
+  abort_chk(
+    x_name,
+    "must be a valid array of fecundity rates.
+            See `bbs_fecundity_caribou()` and `bbs_fecundity()` for details."
+  )
 }
 
 .chk_nyears <- function(survival, fecundity) {
@@ -35,5 +41,8 @@
     return(invisible(survival))
   }
   x_name <- deparse_backtick_chk(substitute(survival))
-  abort_chk(x_name, " must have the same number of years as `fecundity` object.")
+  abort_chk(
+    x_name,
+    " must have the same number of years as `fecundity` object."
+  )
 }

--- a/R/demography.R
+++ b/R/demography.R
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-initial_population <- function(adult_females,
-                               stable_stage_dist) {
+initial_population <- function(adult_females, stable_stage_dist) {
   n_af <- adult_females
   dist_a <- stable_stage_dist[3]
   dist_y <- stable_stage_dist[2]
@@ -30,37 +29,58 @@ initial_population <- function(adult_females,
   ))
 }
 
-female_calves <- function(proportion_female, survival_adult_female, calves_per_adult_female) {
+female_calves <- function(
+  proportion_female,
+  survival_adult_female,
+  calves_per_adult_female
+) {
   proportion_female * survival_adult_female * calves_per_adult_female
 }
 
-calf_cow_ratio <- function(calves_per_adult_female,
-                           survival_adult_female,
-                           survival_calf,
-                           survival_yearling) {
-  (calves_per_adult_female * survival_calf) / (survival_adult_female + 0.5 * survival_yearling)
+calf_cow_ratio <- function(
+  calves_per_adult_female,
+  survival_adult_female,
+  survival_calf,
+  survival_yearling
+) {
+  (calves_per_adult_female * survival_calf) /
+    (survival_adult_female + 0.5 * survival_yearling)
 }
 
 decesare_recruitment <- function(calf_cow, proportion_female) {
   calf_cow * proportion_female / (1 + calf_cow * proportion_female)
 }
 
-leslie_matrix <- function(female_calves, survival_calf, survival_yearling, survival_adult_female) {
+leslie_matrix <- function(
+  female_calves,
+  survival_calf,
+  survival_yearling,
+  survival_adult_female
+) {
   matrix(
     c(
-      0, 0, female_calves,
-      survival_calf, 0, 0,
-      0, survival_yearling, survival_adult_female
+      0,
+      0,
+      female_calves,
+      survival_calf,
+      0,
+      0,
+      0,
+      survival_yearling,
+      survival_adult_female
     ),
-    nrow = 3, byrow = TRUE
+    nrow = 3,
+    byrow = TRUE
   )
 }
 
-stable_stage_distribution <- function(calves_per_adult_female,
-                                      survival_adult_female,
-                                      survival_calf,
-                                      survival_yearling,
-                                      proportion_female) {
+stable_stage_distribution <- function(
+  calves_per_adult_female,
+  survival_adult_female,
+  survival_calf,
+  survival_yearling,
+  proportion_female
+) {
   female_calves <- female_calves(
     proportion_female = proportion_female,
     survival_adult_female = survival_adult_female,
@@ -77,11 +97,13 @@ stable_stage_distribution <- function(calves_per_adult_female,
   popbio::stable.stage(leslie)
 }
 
-estimate_lambda <- function(calves_per_adult_female,
-                            survival_adult_female,
-                            survival_calf,
-                            survival_yearling,
-                            proportion_female) {
+estimate_lambda <- function(
+  calves_per_adult_female,
+  survival_adult_female,
+  survival_calf,
+  survival_yearling,
+  proportion_female
+) {
   female_calves <- female_calves(
     proportion_female = proportion_female,
     survival_adult_female = survival_adult_female,
@@ -111,11 +133,13 @@ estimate_lambda <- function(calves_per_adult_female,
 #' @export
 #' @examples
 #' bbs_demographic_summary()
-bbs_demographic_summary <- function(calves_per_adult_female = 0.7,
-                                    survival_adult_female = 0.85,
-                                    survival_calf = 0.5,
-                                    survival_yearling = survival_adult_female,
-                                    proportion_female = 0.5) {
+bbs_demographic_summary <- function(
+  calves_per_adult_female = 0.7,
+  survival_adult_female = 0.85,
+  survival_calf = 0.5,
+  survival_yearling = survival_adult_female,
+  proportion_female = 0.5
+) {
   calf_cow <- calf_cow_ratio(
     calves_per_adult_female = calves_per_adult_female,
     survival_adult_female = survival_adult_female,
@@ -123,7 +147,8 @@ bbs_demographic_summary <- function(calves_per_adult_female = 0.7,
     survival_yearling = survival_yearling
   )
 
-  recruitment <- decesare_recruitment(calf_cow,
+  recruitment <- decesare_recruitment(
+    calf_cow,
     proportion_female = proportion_female
   )
 

--- a/R/group-survey.R
+++ b/R/group-survey.R
@@ -26,13 +26,15 @@
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' x <- bbs_population_caribou(survival, fecundity = fecundity, adult_females = 100)
 #' bbs_population_groups_survey(x, group_coverage = 0.1)
-bbs_population_groups_survey <- function(population,
-                                         month_composition = 9,
-                                         group_size_lambda = 5,
-                                         group_size_theta = 2,
-                                         group_max_proportion = 1 / 4,
-                                         group_min_size = 2,
-                                         group_coverage = 0.2) {
+bbs_population_groups_survey <- function(
+  population,
+  month_composition = 9,
+  group_size_lambda = 5,
+  group_size_theta = 2,
+  group_max_proportion = 1 / 4,
+  group_min_size = 2,
+  group_coverage = 0.2
+) {
   chk_matrix(population)
   chk_whole_numeric(population)
   chk_whole_number(month_composition)
@@ -54,15 +56,18 @@ bbs_population_groups_survey <- function(population,
   survey <- c(composition_ind, composition_ind + 12 * 1:nyear)
   survey <- survey[survey <= nstep]
 
-  purrr::map(seq_along(survey), ~ {
-    pop <- population[, survey[.x]]
-    y <- population1_groups(
-      population = pop,
-      group_size_lambda = group_size_lambda,
-      group_size_theta = group_size_theta,
-      group_max_proportion = group_max_proportion,
-      group_min_size = group_min_size
-    )
-    sample(y, round(group_coverage * length(y)))
-  })
+  purrr::map(
+    seq_along(survey),
+    ~ {
+      pop <- population[, survey[.x]]
+      y <- population1_groups(
+        population = pop,
+        group_size_lambda = group_size_lambda,
+        group_size_theta = group_size_theta,
+        group_max_proportion = group_max_proportion,
+        group_min_size = group_min_size
+      )
+      sample(y, round(group_coverage * length(y)))
+    }
+  )
 }

--- a/R/group.R
+++ b/R/group.R
@@ -23,7 +23,14 @@ ran_group_size <- function(lambda, theta, max_size, min_size) {
 }
 
 # sample groups until total reached - return as cumulative sum including 0 and total, for use as index
-sample_groups <- function(total, lambda, theta, max_size, min_size, cumulative = TRUE) {
+sample_groups <- function(
+  total,
+  lambda,
+  theta,
+  max_size,
+  min_size,
+  cumulative = TRUE
+) {
   sizes <- vector()
   capacity <- FALSE
   while (!capacity) {
@@ -33,8 +40,9 @@ sample_groups <- function(total, lambda, theta, max_size, min_size, cumulative =
   }
   sizes <- sizes[-length(sizes)]
   # if remainder is too small, consumed by previous
-  if (total - sum(sizes) < min_size)
+  if (total - sum(sizes) < min_size) {
     sizes <- sizes[-length(sizes)]
+  }
 
   if (cumulative) {
     sizes <- c(0, cumsum(sizes), total)
@@ -64,14 +72,21 @@ break_up_pair <- function(x) {
 
 # from stage totals create vector of individuals numbered by stage
 population_individuals <- function(population, shuffle = TRUE) {
-  x <- unlist(purrr::map(seq_along(population), function(x) rep(x, population[x])))
-  if (shuffle)
+  x <- unlist(purrr::map(seq_along(population), function(x) {
+    rep(x, population[x])
+  }))
+  if (shuffle) {
     x <- sample(x)
+  }
   x
 }
 
 # create recruit-female pairs, #pairs = min(recruits, females)
-individuals_to_pairs <- function(x, recruit_stages, reproductive_female_stages) {
+individuals_to_pairs <- function(
+  x,
+  recruit_stages,
+  reproductive_female_stages
+) {
   index <- seq_along(x)
   recruits <- index[x %in% recruit_stages]
   females <- index[x %in% reproductive_female_stages]
@@ -85,11 +100,13 @@ individuals_to_pairs <- function(x, recruit_stages, reproductive_female_stages) 
 }
 
 # population in a single period
-population1_groups <- function(population,
-                               group_size_lambda,
-                               group_size_theta,
-                               group_max_proportion,
-                               group_min_size) {
+population1_groups <- function(
+  population,
+  group_size_lambda,
+  group_size_theta,
+  group_max_proportion,
+  group_min_size
+) {
   total <- sum(population)
   individuals <- population_individuals(population, shuffle = TRUE)
   index <- 1:total
@@ -100,7 +117,8 @@ population1_groups <- function(population,
   if ((floor(max_size) - 1) <= min_size) {
     return(list(individuals))
   } else {
-    sizes <- sample_groups(total,
+    sizes <- sample_groups(
+      total,
       lambda = group_size_lambda,
       theta = group_size_theta,
       max_size = max_size,
@@ -114,22 +132,26 @@ population1_groups <- function(population,
   })
 }
 
-population1_groups_pairs <- function(population,
-                                     group_size_lambda,
-                                     group_size_theta,
-                                     group_max_proportion,
-                                     group_min_size,
-                                     recruit_stages,
-                                     reproductive_female_stages) {
+population1_groups_pairs <- function(
+  population,
+  group_size_lambda,
+  group_size_theta,
+  group_max_proportion,
+  group_min_size,
+  recruit_stages,
+  reproductive_female_stages
+) {
   total <- sum(population)
   individuals <- population_individuals(population)
-  pairs <- individuals_to_pairs(individuals,
+  pairs <- individuals_to_pairs(
+    individuals,
     recruit_stages = recruit_stages,
     reproductive_female_stages = reproductive_female_stages
   )
   names(pairs) <- seq_along(pairs)
 
-  sizes <- sample_groups(total,
+  sizes <- sample_groups(
+    total,
     lambda = group_size_lambda,
     theta = group_size_theta,
     max_size = total * group_max_proportion,
@@ -178,11 +200,13 @@ population1_groups_pairs <- function(population,
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' x <- bbs_population_caribou(survival, fecundity = fecundity, adult_females = 100)
 #' bbs_population_groups(x)
-bbs_population_groups <- function(population,
-                                  group_size_lambda = 5,
-                                  group_size_theta = 2,
-                                  group_max_proportion = 1 / 4,
-                                  group_min_size = 2) {
+bbs_population_groups <- function(
+  population,
+  group_size_lambda = 5,
+  group_size_theta = 2,
+  group_max_proportion = 1 / 4,
+  group_min_size = 2
+) {
   chk_matrix(population)
   chk_whole_numeric(population)
   chk_number(group_size_lambda)
@@ -196,14 +220,18 @@ bbs_population_groups <- function(population,
 
   population <- as.matrix(population)
   nstep <- ncol(population)
-  purrr::map(seq_len(nstep), ~ {
-    population1_groups(population[, .x],
-      group_size_lambda = group_size_lambda,
-      group_size_theta = group_size_theta,
-      group_max_proportion = group_max_proportion,
-      group_min_size = group_min_size
-    )
-  })
+  purrr::map(
+    seq_len(nstep),
+    ~ {
+      population1_groups(
+        population[, .x],
+        group_size_lambda = group_size_lambda,
+        group_size_theta = group_size_theta,
+        group_max_proportion = group_max_proportion,
+        group_min_size = group_min_size
+      )
+    }
+  )
 }
 
 #' Assign population into groups by pairs
@@ -226,13 +254,15 @@ bbs_population_groups <- function(population,
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' x <- bbs_population_caribou(survival, fecundity = fecundity, adult_females = 100)
 #' bbs_population_groups_pairs(x)
-bbs_population_groups_pairs <- function(population,
-                                        group_size_lambda = 5,
-                                        group_size_theta = 2,
-                                        group_max_proportion = 1 / 4,
-                                        group_min_size = 2,
-                                        recruit_stages = c(1, 2),
-                                        reproductive_female_stages = c(3, 5)) {
+bbs_population_groups_pairs <- function(
+  population,
+  group_size_lambda = 5,
+  group_size_theta = 2,
+  group_max_proportion = 1 / 4,
+  group_min_size = 2,
+  recruit_stages = c(1, 2),
+  reproductive_female_stages = c(3, 5)
+) {
   chk_matrix(population)
   chk_whole_numeric(population)
   chk_number(group_size_lambda)
@@ -252,7 +282,8 @@ bbs_population_groups_pairs <- function(population,
   population <- as.matrix(population)
   nstep <- ncol(population)
   purrr::map(seq_len(nstep), function(x) {
-    population1_groups_pairs(population[, x],
+    population1_groups_pairs(
+      population[, x],
       group_size_lambda = group_size_lambda,
       group_size_theta = group_size_theta,
       group_max_proportion = group_max_proportion,

--- a/R/plot-population.R
+++ b/R/plot-population.R
@@ -35,11 +35,14 @@ bbs_plot_population <- function(x, ...) {
 bbs_plot_population.data.frame <- function(x, annual = TRUE, ...) {
   chk_unused(...)
   chk_flag(annual)
-  check_data(x, values = list(
-    Stage = factor(""),
-    Year = c(0),
-    Abundance = c(0)
-  ))
+  check_data(
+    x,
+    values = list(
+      Stage = factor(""),
+      Year = c(0),
+      Abundance = c(0)
+    )
+  )
 
   if (annual) {
     x <-
@@ -54,7 +57,17 @@ bbs_plot_population.data.frame <- function(x, annual = TRUE, ...) {
     gp <- ggplot(data = x) +
       geom_line(aes(x = .data$Period, y = .data$Abundance, color = .data$Stage))
   }
-  gp + scale_color_manual(values = c("#000000", "#3063A3", "#E8613C", "#F7B500", "#821C65", "#63BB42"))
+  gp +
+    scale_color_manual(
+      values = c(
+        "#000000",
+        "#3063A3",
+        "#E8613C",
+        "#F7B500",
+        "#821C65",
+        "#63BB42"
+      )
+    )
 }
 
 #' @describeIn bbs_plot_population Plot population abundance by period and stage for a matrix (output of [bbs_population_caribou()]).
@@ -75,7 +88,12 @@ bbs_plot_population.data.frame <- function(x, annual = TRUE, ...) {
 #'   survival = survival_mat
 #' )
 #' bbs_plot_population(x)
-bbs_plot_population.bbou_population <- function(x, annual = TRUE, nperiod_within_year = 12, ...) {
+bbs_plot_population.bbou_population <- function(
+  x,
+  annual = TRUE,
+  nperiod_within_year = 12,
+  ...
+) {
   chk_unused(...)
   chk_flag(annual)
   chk_whole_number(nperiod_within_year)
@@ -95,7 +113,12 @@ bbs_plot_population.bbou_population <- function(x, annual = TRUE, nperiod_within
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' x <- bbs_simulate_caribou(survival, fecundity = fecundity, nsims = 3)
 #' bbs_plot_population(x, alpha = 0.7)
-bbs_plot_population.bbou_simulation <- function(x, annual = TRUE, alpha = 0.5, ...) {
+bbs_plot_population.bbou_simulation <- function(
+  x,
+  annual = TRUE,
+  alpha = 0.5,
+  ...
+) {
   chk_unused(...)
   chk_flag(annual)
   chk_range(alpha)
@@ -112,13 +135,39 @@ bbs_plot_population.bbou_simulation <- function(x, annual = TRUE, alpha = 0.5, .
       ungroup()
 
     gp <- ggplot(data = x) +
-      geom_line(aes(x = factor(.data$Year), y = .data$Abundance, color = .data$Stage, group = .data$group), alpha = alpha) +
+      geom_line(
+        aes(
+          x = factor(.data$Year),
+          y = .data$Abundance,
+          color = .data$Stage,
+          group = .data$group
+        ),
+        alpha = alpha
+      ) +
       xlab("Year")
   } else {
     gp <- ggplot(data = x) +
-      geom_line(aes(x = .data$Period, y = .data$Abundance, color = .data$Stage, group = .data$group), alpha = alpha)
+      geom_line(
+        aes(
+          x = .data$Period,
+          y = .data$Abundance,
+          color = .data$Stage,
+          group = .data$group
+        ),
+        alpha = alpha
+      )
   }
-  gp + scale_color_manual(values = c("#000000", "#3063A3", "#E8613C", "#F7B500", "#821C65", "#63BB42"))
+  gp +
+    scale_color_manual(
+      values = c(
+        "#000000",
+        "#3063A3",
+        "#E8613C",
+        "#F7B500",
+        "#821C65",
+        "#63BB42"
+      )
+    )
 }
 
 #' @describeIn bbs_plot_population Plot population abundance by period and stage for a matrix (output of [bbs_simulate_caribou()]).

--- a/R/population.R
+++ b/R/population.R
@@ -13,15 +13,20 @@
 # limitations under the License.
 
 rbinom_map <- function(size, prob) {
-  purrr::map_dbl(size, ~ {
-    rbinom(1, size = round(.x / prob), prob = 1 - prob)
-  })
+  purrr::map_dbl(
+    size,
+    ~ {
+      rbinom(1, size = round(.x / prob), prob = 1 - prob)
+    }
+  )
 }
 
-add_male_population <- function(population,
-                                proportion_adult_female,
-                                proportion_yearling_female,
-                                stochastic) {
+add_male_population <- function(
+  population,
+  proportion_adult_female,
+  proportion_yearling_female,
+  stochastic
+) {
   m <- matrix(NA, nrow = 6, ncol = ncol(population))
   m[1, ] <- population[1, ]
   m[3, ] <- population[2, ]
@@ -68,11 +73,13 @@ add_male_population <- function(population,
 #'   age = age_mat,
 #'   survival = survival_mat
 #' )
-bbs_population <- function(population_init,
-                           birth,
-                           age,
-                           survival,
-                           stochastic = TRUE) {
+bbs_population <- function(
+  population_init,
+  birth,
+  age,
+  survival,
+  stochastic = TRUE
+) {
   chk_whole_numeric(population_init)
   chk_array(birth)
   chk_length(dim(birth), 3L)
@@ -105,10 +112,16 @@ bbs_population <- function(population_init,
       period_now <- (year - 1) * nperiod + period
       if (period == nperiod) {
         abundance[, period_now + 1] <-
-          mmult(birth[, , year], mmult(age, mmult(survival[, , year, period], abundance[, period_now])))
+          mmult(
+            birth[,, year],
+            mmult(
+              age,
+              mmult(survival[,, year, period], abundance[, period_now])
+            )
+          )
       } else {
         abundance[, period_now + 1] <-
-          mmult(survival[, , year, period], abundance[, period_now])
+          mmult(survival[,, year, period], abundance[, period_now])
       }
     }
   }
@@ -136,12 +149,14 @@ bbs_population <- function(population_init,
 #' survival <- bbs_survival_caribou(0.84)
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' x <- bbs_population_caribou(survival, fecundity = fecundity)
-bbs_population_caribou <- function(survival,
-                                   fecundity,
-                                   adult_females = 1000,
-                                   proportion_adult_female = 0.65,
-                                   proportion_yearling_female = 0.5,
-                                   stochastic = TRUE) {
+bbs_population_caribou <- function(
+  survival,
+  fecundity,
+  adult_females = 1000,
+  proportion_adult_female = 0.65,
+  proportion_yearling_female = 0.5,
+  stochastic = TRUE
+) {
   .chk_survival(survival)
   .chk_fecundity(fecundity)
   .chk_nyears(survival, fecundity)
@@ -178,7 +193,8 @@ bbs_population_caribou <- function(survival,
     stochastic = stochastic
   )
 
-  x <- add_male_population(population,
+  x <- add_male_population(
+    population,
     proportion_adult_female = proportion_adult_female,
     proportion_yearling_female = proportion_yearling_female,
     stochastic = stochastic

--- a/R/recruitment.R
+++ b/R/recruitment.R
@@ -14,8 +14,22 @@
 
 abundance_tbl <- function(population, population_name = "A") {
   colnames(population) <- seq_len(ncol(population))
-  stages <- c("Female Calf", "Male Calf", "Female Yearling", "Male Yearling", "Female Adult", "Male Adult")
-  levels <- c("Female Adult", "Male Adult", "Female Yearling", "Male Yearling", "Female Calf", "Male Calf")
+  stages <- c(
+    "Female Calf",
+    "Male Calf",
+    "Female Yearling",
+    "Male Yearling",
+    "Female Adult",
+    "Male Adult"
+  )
+  levels <- c(
+    "Female Adult",
+    "Male Adult",
+    "Female Yearling",
+    "Male Yearling",
+    "Female Calf",
+    "Male Calf"
+  )
   nstep <- ncol(population) + 1
   population %>%
     as.data.frame() %>%
@@ -23,7 +37,11 @@ abundance_tbl <- function(population, population_name = "A") {
       Stage = stages,
       Stage = factor(.data$Stage, levels = levels)
     ) %>%
-    pivot_longer(-all_of(nstep), names_to = "Period", values_to = "Abundance") %>%
+    pivot_longer(
+      -all_of(nstep),
+      names_to = "Period",
+      values_to = "Abundance"
+    ) %>%
     mutate(
       Period = as.integer(.data$Period) - 1,
       Year = period_to_year(.data$Period),
@@ -33,11 +51,13 @@ abundance_tbl <- function(population, population_name = "A") {
     select("Year", "Month", "Period", "PopulationName", "Stage", "Abundance")
 }
 
-recruitment_tbl <- function(groups,
-                            month_composition,
-                            probability_unsexed_adult_male,
-                            probability_unsexed_adult_female,
-                            population_name) {
+recruitment_tbl <- function(
+  groups,
+  month_composition,
+  probability_unsexed_adult_male,
+  probability_unsexed_adult_female,
+  population_name
+) {
   purrr::map_df(seq_along(groups), function(x) {
     group <- groups[[x]]
     prob_unsexed_female <- probability_unsexed_adult_female

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -39,69 +39,73 @@
 #' fecundity <- bbs_fecundity_caribou(0.7)
 #' caribou <- bbs_simulate_caribou(survival, fecundity = fecundity, nsims = 2)
 bbs_simulate_caribou <- function(
-    survival,
-    fecundity,
-    nsims = 1,
-    adult_females = 500,
-    proportion_adult_female = 0.65,
-    proportion_yearling_female = 0.5,
-    probability_unsexed_adult_female = 0,
-    probability_unsexed_adult_male = 0,
-    month_composition = 9L,
-    group_size = 5,
-    group_coverage = 0.3,
-    group_min_size = 2,
-    group_max_proportion = 1,
-    collared_adult_females = 30,
-    month_collar = 1L,
-    probability_uncertain_mortality = 0,
-    probability_uncertain_survival = 0,
-    population_name = "A") {
-  x <- purrr::map(seq_len(nsims), ~ {
-    population <- bbs_population_caribou(
-      survival = survival,
-      fecundity = fecundity,
-      adult_females = adult_females,
-      proportion_adult_female = proportion_adult_female,
-      proportion_yearling_female = proportion_yearling_female
-    )
+  survival,
+  fecundity,
+  nsims = 1,
+  adult_females = 500,
+  proportion_adult_female = 0.65,
+  proportion_yearling_female = 0.5,
+  probability_unsexed_adult_female = 0,
+  probability_unsexed_adult_male = 0,
+  month_composition = 9L,
+  group_size = 5,
+  group_coverage = 0.3,
+  group_min_size = 2,
+  group_max_proportion = 1,
+  collared_adult_females = 30,
+  month_collar = 1L,
+  probability_uncertain_mortality = 0,
+  probability_uncertain_survival = 0,
+  population_name = "A"
+) {
+  x <- purrr::map(
+    seq_len(nsims),
+    ~ {
+      population <- bbs_population_caribou(
+        survival = survival,
+        fecundity = fecundity,
+        adult_females = adult_females,
+        proportion_adult_female = proportion_adult_female,
+        proportion_yearling_female = proportion_yearling_female
+      )
 
-    groups <- bbs_population_groups_survey(population,
-      month_composition = month_composition,
-      group_size_lambda = group_size,
-      group_size_theta = 0,
-      group_coverage = group_coverage,
-      group_min_size = group_min_size,
-      group_max_proportion = group_max_proportion
-    )
+      groups <- bbs_population_groups_survey(
+        population,
+        month_composition = month_composition,
+        group_size_lambda = group_size,
+        group_size_theta = 0,
+        group_coverage = group_coverage,
+        group_min_size = group_min_size,
+        group_max_proportion = group_max_proportion
+      )
 
-    abundance <- abundance_tbl(population,
-      population_name = population_name
-    )
+      abundance <- abundance_tbl(population, population_name = population_name)
 
-    recruitment <- recruitment_tbl(groups,
-      month_composition = month_composition,
-      probability_unsexed_adult_male = probability_unsexed_adult_male,
-      probability_unsexed_adult_female = probability_unsexed_adult_female,
-      population_name = population_name
-    )
+      recruitment <- recruitment_tbl(
+        groups,
+        month_composition = month_composition,
+        probability_unsexed_adult_male = probability_unsexed_adult_male,
+        probability_unsexed_adult_female = probability_unsexed_adult_female,
+        population_name = population_name
+      )
 
-    survival_adult_female_month_year <- survival$eSurvival[, , 3]
-    survival <- bbs_survival_collared(
-      collared_adult_females = collared_adult_females,
-      month_collar = month_collar,
-      survival_adult_female_month_year = survival_adult_female_month_year,
-      probability_uncertain_mortality = probability_uncertain_mortality,
-      probability_uncertain_survival = probability_uncertain_survival,
-      population_name = population_name
-    )
+      survival_adult_female_month_year <- survival$eSurvival[,, 3]
+      survival <- bbs_survival_collared(
+        collared_adult_females = collared_adult_females,
+        month_collar = month_collar,
+        survival_adult_female_month_year = survival_adult_female_month_year,
+        probability_uncertain_mortality = probability_uncertain_mortality,
+        probability_uncertain_survival = probability_uncertain_survival,
+        population_name = population_name
+      )
 
-    list(
-      survival = survival,
-      recruitment = recruitment,
-      abundance = abundance
-    )
-  })
+      list(
+        survival = survival,
+        recruitment = recruitment,
+        abundance = abundance
+      )
+    }
+  )
 
   x <- class_bbou_simulation(x)
   x

--- a/R/survival-collared.R
+++ b/R/survival-collared.R
@@ -31,42 +31,50 @@
 #'   collared_adult_females = 30,
 #'   survival_adult_female_month_year = survival_adult_female
 #' )
-bbs_survival_collared <- function(collared_adult_females,
-                                  survival_adult_female_month_year,
-                                  probability_uncertain_mortality = 0,
-                                  probability_uncertain_survival = 0,
-                                  month_collar = 1L,
-                                  population_name = "A") {
+bbs_survival_collared <- function(
+  collared_adult_females,
+  survival_adult_female_month_year,
+  probability_uncertain_mortality = 0,
+  probability_uncertain_survival = 0,
+  month_collar = 1L,
+  population_name = "A"
+) {
   starttotal <- collared_adult_females
   nyear <- ncol(survival_adult_female_month_year)
   yearmon <- tidyr::expand_grid(year = 1:nyear, month = 1:12)
   # remove first months without collaring
-  yearmon <- dplyr::filter(yearmon, !(.data$year == 1 & .data$month < month_collar))
+  yearmon <- dplyr::filter(
+    yearmon,
+    !(.data$year == 1 & .data$month < month_collar)
+  )
 
-  purrr::map_df(seq_len(nrow(yearmon)), ~ {
-    month <- yearmon$month[.x]
-    year <- yearmon$year[.x]
-    phi <- survival_adult_female_month_year[month, year]
-    prob_uncertain_mort <- probability_uncertain_mortality
-    prob_uncertain_surv <- probability_uncertain_survival
-    last <- starttotal[length(starttotal)]
-    dead <- rbinom(1, last, (1 - phi))
-    dead_uncertain <- rbinom(1, dead, prob_uncertain_mort)
-    dead_certain <- dead - dead_uncertain
-    alive_uncertain <- rbinom(1, last, prob_uncertain_surv)
-    update <- last - dead - alive_uncertain
-    if (month == month_collar - 1 || (month == 12 & month_collar == 1)) {
-      starttotal <<- c(starttotal, collared_adult_females)
-    } else {
-      starttotal <<- c(starttotal, update)
+  purrr::map_df(
+    seq_len(nrow(yearmon)),
+    ~ {
+      month <- yearmon$month[.x]
+      year <- yearmon$year[.x]
+      phi <- survival_adult_female_month_year[month, year]
+      prob_uncertain_mort <- probability_uncertain_mortality
+      prob_uncertain_surv <- probability_uncertain_survival
+      last <- starttotal[length(starttotal)]
+      dead <- rbinom(1, last, (1 - phi))
+      dead_uncertain <- rbinom(1, dead, prob_uncertain_mort)
+      dead_certain <- dead - dead_uncertain
+      alive_uncertain <- rbinom(1, last, prob_uncertain_surv)
+      update <- last - dead - alive_uncertain
+      if (month == month_collar - 1 || (month == 12 & month_collar == 1)) {
+        starttotal <<- c(starttotal, collared_adult_females)
+      } else {
+        starttotal <<- c(starttotal, update)
+      }
+      tibble(
+        Year = year,
+        Month = month,
+        PopulationName = population_name,
+        StartTotal = last,
+        MortalitiesCertain = dead_certain,
+        MortalitiesUncertain = dead_uncertain
+      )
     }
-    tibble(
-      Year = year,
-      Month = month,
-      PopulationName = population_name,
-      StartTotal = last,
-      MortalitiesCertain = dead_certain,
-      MortalitiesUncertain = dead_uncertain
-    )
-  })
+  )
 }

--- a/R/survival-matrix.R
+++ b/R/survival-matrix.R
@@ -51,7 +51,7 @@ bbs_matrix_survival_period <- function(survival) {
   x <- array(0, dim = c(nstate, nstate, nyear, nperiod))
   for (year in 1:nyear) {
     for (period in 1:nperiod) {
-      x[, , year, period] <- bbs_matrix_survival(survival[period, year, ])
+      x[,, year, period] <- bbs_matrix_survival(survival[period, year, ])
     }
   }
   x

--- a/R/survival.R
+++ b/R/survival.R
@@ -36,18 +36,20 @@
 #'
 #' @examples
 #' survival <- bbs_survival_caribou(0.84, survival_calf_female = 0.5)
-bbs_survival_caribou <- function(survival_adult_female,
-                                 survival_calf_female = 0.5,
-                                 nyear = 10,
-                                 trend_adult_female = 0,
-                                 annual_sd_adult_female = 0,
-                                 month_sd_adult_female = 0,
-                                 annual_month_sd_adult_female = 0,
-                                 trend_calf_female = 0,
-                                 annual_sd_calf_female = 0,
-                                 month_sd_calf_female = 0,
-                                 annual_month_sd_calf_female = 0,
-                                 yearling_effect = 0) {
+bbs_survival_caribou <- function(
+  survival_adult_female,
+  survival_calf_female = 0.5,
+  nyear = 10,
+  trend_adult_female = 0,
+  annual_sd_adult_female = 0,
+  month_sd_adult_female = 0,
+  annual_month_sd_adult_female = 0,
+  trend_calf_female = 0,
+  annual_sd_calf_female = 0,
+  month_sd_calf_female = 0,
+  annual_month_sd_calf_female = 0,
+  yearling_effect = 0
+) {
   chk_number(survival_adult_female)
   chk_range(survival_adult_female)
   chk_number(survival_calf_female)
@@ -72,7 +74,11 @@ bbs_survival_caribou <- function(survival_adult_female,
   trend <- c(trend_calf_female, 0, trend_adult_female)
   annual_sd <- c(annual_sd_calf_female, 0, annual_sd_adult_female)
   period_sd <- c(month_sd_calf_female, 0, month_sd_adult_female)
-  annual_period_sd <- c(annual_month_sd_calf_female, 0, annual_month_sd_adult_female)
+  annual_period_sd <- c(
+    annual_month_sd_calf_female,
+    0,
+    annual_month_sd_adult_female
+  )
 
   x <- bbs_survival(
     intercept = intercept,
@@ -85,7 +91,7 @@ bbs_survival_caribou <- function(survival_adult_female,
   )
 
   # add yearling effect
-  x$eSurvival[, , 2] <- ilogit(logit(x$eSurvival[, , 3]) + yearling_effect)
+  x$eSurvival[,, 2] <- ilogit(logit(x$eSurvival[,, 3]) + yearling_effect)
   x
 }
 
@@ -108,13 +114,15 @@ bbs_survival_caribou <- function(survival_adult_female,
 #'
 #' @examples
 #' survival <- bbs_survival(intercept = logit(c(0.94, 0.98, 0.98)), trend = c(0, 0, 0.2))
-bbs_survival <- function(intercept,
-                         nyear = 10,
-                         trend = rep(0, length(intercept)),
-                         annual_sd = rep(0, length(intercept)),
-                         period_sd = rep(0, length(intercept)),
-                         annual_period_sd = rep(0, length(intercept)),
-                         nperiod_within_year = 12) {
+bbs_survival <- function(
+  intercept,
+  nyear = 10,
+  trend = rep(0, length(intercept)),
+  annual_sd = rep(0, length(intercept)),
+  period_sd = rep(0, length(intercept)),
+  annual_period_sd = rep(0, length(intercept)),
+  nperiod_within_year = 12
+) {
   chk_numeric(intercept)
   chk_whole_number(nyear)
   chk_gt(nyear)
@@ -158,7 +166,13 @@ bbs_survival <- function(intercept,
   for (yr in 1:nyear) {
     for (prd in 1:nperiod) {
       for (stg in 1:nstage) {
-        esurvival[prd, yr, stg] <- ilogit(intercept[stg] + trend[stg] * year[yr] + bannual[yr, stg] + bperiod[prd, stg] + bannual_period[yr, prd, stg])
+        esurvival[prd, yr, stg] <- ilogit(
+          intercept[stg] +
+            trend[stg] * year[yr] +
+            bannual[yr, stg] +
+            bperiod[prd, stg] +
+            bannual_period[yr, prd, stg]
+        )
       }
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,9 +39,16 @@ population_tbl <- function(x, nperiod_within_year = 12) {
   x %>%
     as.data.frame() %>%
     mutate(Stage = factor(seq_len(nrow(x)))) %>%
-    pivot_longer(-all_of(nstep), names_to = "Period", values_to = "Abundance") %>%
+    pivot_longer(
+      -all_of(nstep),
+      names_to = "Period",
+      values_to = "Abundance"
+    ) %>%
     mutate(
       Period = as.integer(.data$Period) - 1,
-      Year = period_to_year(.data$Period, nperiod_within_year = nperiod_within_year)
+      Year = period_to_year(
+        .data$Period,
+        nperiod_within_year = nperiod_within_year
+      )
     )
 }

--- a/R/vld.R
+++ b/R/vld.R
@@ -15,7 +15,10 @@
 .vld_survival <- function(x) {
   all(
     vld_true(inherits(x, "list")),
-    vld_identical(names(x), c("eSurvival", "b0", "bYear", "bAnnual", "bPeriod", "bAnnualPeriod")),
+    vld_identical(
+      names(x),
+      c("eSurvival", "b0", "bYear", "bAnnual", "bPeriod", "bAnnualPeriod")
+    ),
     vld_equal(length(dim(x$eSurvival)), 3)
   )
 }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -19,9 +19,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = lintr::linters_with_defaults(
-  line_length_linter = lintr::line_length_linter(1000),
-  object_name_linter = lintr::object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = lintr::linters_with_defaults(
+    line_length_linter = lintr::line_length_linter(1000),
+    object_name_linter = lintr::object_name_linter(regexes = ".*")
+  )
 )
 
 # lintr::lint_package()

--- a/tests/testthat/test-birth-matrix.R
+++ b/tests/testthat/test-birth-matrix.R
@@ -55,7 +55,12 @@ test_that("can change female proportion", {
 
 test_that("can change calf stage indices", {
   rates <- c(0.4, 0, 0)
-  x <- bbs_matrix_birth(rates, male_recruit_stage = 3, female_recruit_stage = 2, proportion_female = 0.75)
+  x <- bbs_matrix_birth(
+    rates,
+    male_recruit_stage = 3,
+    female_recruit_stage = 2,
+    proportion_female = 0.75
+  )
   expect_snapshot({
     print(x)
   })
@@ -63,10 +68,18 @@ test_that("can change calf stage indices", {
 
 test_that("birth process matrices work", {
   # 4 seasons, 2 years, 2 stages
-  rates <- matrix(c(
-    0, 0, 0.2,
-    0, 0, 0.3
-  ), nrow = 2, byrow = TRUE)
+  rates <- matrix(
+    c(
+      0,
+      0,
+      0.2,
+      0,
+      0,
+      0.3
+    ),
+    nrow = 2,
+    byrow = TRUE
+  )
   x <- bbs_matrix_birth_year(rates)
   expect_identical(dim(x), c(3L, 3L, 2L))
   expect_snapshot({

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -16,7 +16,11 @@ test_that("assign population to groups", {
   withr::with_seed(10, {
     survival <- bbs_survival_caribou(0.84)
     fecundity <- bbs_fecundity_caribou(0.2)
-    population <- bbs_population_caribou(survival = survival, fecundity = fecundity, adult_females = 1000)
+    population <- bbs_population_caribou(
+      survival = survival,
+      fecundity = fecundity,
+      adult_females = 1000
+    )
 
     min_size <- 2
     max_proportion <- 0.75
@@ -39,7 +43,10 @@ test_that("assign population to groups", {
 
   # check same individuals as in population for each period when unlist groups
   individuals <-
-    purrr::map(seq_len(ncol(population)), ~ sort(population_individuals(population[, .x])))
+    purrr::map(
+      seq_len(ncol(population)),
+      ~ sort(population_individuals(population[, .x]))
+    )
   for (i in seq_along(individuals)) {
     expect_identical(individuals[[i]], sort(unlist(group[[i]])))
   }
@@ -61,7 +68,11 @@ test_that("sample groups from population", {
   withr::with_seed(10, {
     survival <- bbs_survival_caribou(0.84)
     fecundity <- bbs_fecundity_caribou(0.2)
-    population <- bbs_population_caribou(survival = survival, fecundity = fecundity, adult_females = 1000)
+    population <- bbs_population_caribou(
+      survival = survival,
+      fecundity = fecundity,
+      adult_females = 1000
+    )
 
     min_size <- 2
     max_proportion <- 0.75
@@ -99,7 +110,11 @@ test_that("assign population to groups by pairs", {
   withr::with_seed(10, {
     survival <- bbs_survival_caribou(0.84)
     fecundity <- bbs_fecundity_caribou(0.2)
-    population <- bbs_population_caribou(survival = survival, fecundity = fecundity, adult_females = 1000)
+    population <- bbs_population_caribou(
+      survival = survival,
+      fecundity = fecundity,
+      adult_females = 1000
+    )
 
     min_size <- 2
     max_proportion <- 0.75
@@ -121,7 +136,10 @@ test_that("assign population to groups by pairs", {
   nstep <- ncol(population)
 
   individuals <-
-    purrr::map(seq_len(ncol(population)), ~ sort(population_individuals(population[, .x])))
+    purrr::map(
+      seq_len(ncol(population)),
+      ~ sort(population_individuals(population[, .x]))
+    )
   for (i in seq_along(individuals)) {
     expect_identical(individuals[[i]], sort(unlist(group[[i]])))
   }
@@ -142,7 +160,11 @@ test_that("assign population to groups in declining population to 0", {
   withr::with_seed(101, {
     survival <- bbs_survival_caribou(0.84)
     fecundity <- bbs_fecundity_caribou(0.2)
-    population <- bbs_population_caribou(survival = survival, fecundity = fecundity, adult_females = 1000)
+    population <- bbs_population_caribou(
+      survival = survival,
+      fecundity = fecundity,
+      adult_females = 1000
+    )
     min_size <- 2
     max_proportion <- 1
     lambda <- 6
@@ -165,7 +187,10 @@ test_that("assign population to groups in declining population to 0", {
 
   # check same individuals as in population for each period when unlist groups
   individuals <-
-    purrr::map(seq_len(ncol(population)), ~ sort(population_individuals(population[, .x])))
+    purrr::map(
+      seq_len(ncol(population)),
+      ~ sort(population_individuals(population[, .x]))
+    )
   for (i in seq_along(individuals)) {
     expect_identical(individuals[[i]], sort(unlist(group[[i]])))
   }

--- a/tests/testthat/test-plot-population.R
+++ b/tests/testthat/test-plot-population.R
@@ -63,13 +63,15 @@ test_that("can plot population matrix 2 stages and 4 periods", {
     )
     survival_mat <- bbs_matrix_survival_period(survival$eSurvival)
     birth_mat <-
-      bbs_matrix_birth_year(fecundity$eFecundity,
+      bbs_matrix_birth_year(
+        fecundity$eFecundity,
         female_recruit_stage = 1,
         male_recruit_stage = NULL
       )
     age_mat <- bbs_matrix_age(c(2, 2))
     pop0 <- c(105, 220)
-    x <- bbs_population(pop0,
+    x <- bbs_population(
+      pop0,
       birth = birth_mat,
       age = age_mat,
       survival = survival_mat

--- a/tests/testthat/test-population.R
+++ b/tests/testthat/test-population.R
@@ -32,9 +32,14 @@ test_that("bbs_population works", {
       nyear = nyear
     )
     survival_mat <- bbs_matrix_survival_period(survival$eSurvival)
-    birth_mat <- bbs_matrix_birth_year(fecundity$eFecundity, female_recruit_stage = 1, male_recruit_stage = NULL)
+    birth_mat <- bbs_matrix_birth_year(
+      fecundity$eFecundity,
+      female_recruit_stage = 1,
+      male_recruit_stage = NULL
+    )
     age_mat <- bbs_matrix_age(c(2, 2))
-    x <- bbs_population(pop0,
+    x <- bbs_population(
+      pop0,
       birth = birth_mat,
       age = age_mat,
       survival = survival_mat
@@ -78,10 +83,13 @@ test_that("bbs_population_caribou fails with different number of years", {
       nyear = nyear
     )
     fecundity <- bbs_fecundity_caribou(0.2, nyear = 3)
-    
-    expect_chk_error(bbs_population_caribou(
-      survival = survival,
-      fecundity = fecundity
-    ), regexp = "must have the same number of years") 
+
+    expect_chk_error(
+      bbs_population_caribou(
+        survival = survival,
+        fecundity = fecundity
+      ),
+      regexp = "must have the same number of years"
+    )
   })
 })

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -53,7 +53,8 @@ test_that("bbs_simulate_caribou works with bboutools and values can be recovered
     nyear = nyear
   )
 
-  x <- bbs_simulate_caribou(survival,
+  x <- bbs_simulate_caribou(
+    survival,
     fecundity = fecundity,
     nsims = nsims,
     adult_females = 500,
@@ -63,17 +64,20 @@ test_that("bbs_simulate_caribou works with bboutools and values can be recovered
     collared_adult_females = 200
   )
 
-  fit_r <- bboutools::bb_fit_recruitment(x[[1]]$recruitment,
+  fit_r <- bboutools::bb_fit_recruitment(
+    x[[1]]$recruitment,
     adult_female_proportion = NULL,
     yearling_female_proportion = 0.5
   )
 
-  fit_s <- bboutools::bb_fit_survival(x[[1]]$survival,
+  fit_s <- bboutools::bb_fit_survival(
+    x[[1]]$survival,
     min_random_year = Inf,
-    nthin = 30L, year_start = 1L
+    nthin = 30L,
+    year_start = 1L
   )
 
-  saf <- survival$eSurvival[, , 3]
+  saf <- survival$eSurvival[,, 3]
   nyear <- dim(saf)[2]
   saf_annual <- vector(length = nyear)
   for (yr in 1:nyear) {
@@ -91,6 +95,9 @@ test_that("bbs_simulate_caribou works with bboutools and values can be recovered
   year$actual <- saf_annual
 
   ggplot(data = year) +
-    geom_pointrange(aes(x = CaribouYear, y = estimate, ymin = lower, ymax = upper), alpha = 0.5) +
+    geom_pointrange(
+      aes(x = CaribouYear, y = estimate, ymin = lower, ymax = upper),
+      alpha = 0.5
+    ) +
     geom_point(aes(x = CaribouYear, y = actual), size = 2, color = "red")
 })

--- a/tests/testthat/test-survival-collared.R
+++ b/tests/testthat/test-survival-collared.R
@@ -16,10 +16,8 @@ test_that("survival collared works", {
   withr::with_seed(10, {
     ncollar <- 30
     phi <- bbs_survival_caribou(0.84, survival_calf_female = 0.5)
-    saf <- phi$eSurvival[, , 3]
-    x <- bbs_survival_collared(ncollar,
-      survival_adult_female_month_year = saf
-    )
+    saf <- phi$eSurvival[,, 3]
+    x <- bbs_survival_collared(ncollar, survival_adult_female_month_year = saf)
     expect_true(all(x$StartTotal[x$Month == 1] == ncollar))
     expect_snapshot({
       print(x)
@@ -32,8 +30,9 @@ test_that("survival collared works with different collar month", {
     month_collar <- 3
     ncollar <- 30
     phi <- bbs_survival_caribou(0.84, survival_calf_female = 0.5)
-    saf <- phi$eSurvival[, , 3]
-    x <- bbs_survival_collared(ncollar,
+    saf <- phi$eSurvival[,, 3]
+    x <- bbs_survival_collared(
+      ncollar,
       month_collar = month_collar,
       survival_adult_female_month_year = saf
     )
@@ -47,8 +46,9 @@ test_that("survival collared works with different collar month", {
 test_that("survival collared works with uncertain mort", {
   withr::with_seed(10, {
     phi <- bbs_survival_caribou(0.84, survival_calf_female = 0.5)
-    saf <- phi$eSurvival[, , 3]
-    x <- bbs_survival_collared(30,
+    saf <- phi$eSurvival[,, 3]
+    x <- bbs_survival_collared(
+      30,
       survival_adult_female_month_year = saf,
       probability_uncertain_mortality = 0.5
     )
@@ -61,8 +61,9 @@ test_that("survival collared works with uncertain mort", {
 test_that("survival collared low survival works", {
   withr::with_seed(10, {
     phi <- bbs_survival_caribou(0.1, survival_calf_female = 0.5)
-    saf <- phi$eSurvival[, , 3]
-    x <- bbs_survival_collared(30,
+    saf <- phi$eSurvival[,, 3]
+    x <- bbs_survival_collared(
+      30,
       survival_adult_female_month_year = saf,
       probability_uncertain_mortality = 0.05
     )
@@ -75,8 +76,9 @@ test_that("survival collared low survival works", {
 test_that("survival collared low collars works", {
   withr::with_seed(10, {
     phi <- bbs_survival_caribou(0.1, survival_calf_female = 0.5)
-    saf <- phi$eSurvival[, , 3]
-    x <- bbs_survival_collared(5,
+    saf <- phi$eSurvival[,, 3]
+    x <- bbs_survival_collared(
+      5,
       survival_adult_female_month_year = saf,
       probability_uncertain_mortality = 0.05
     )

--- a/tests/testthat/test-survival-matrix.R
+++ b/tests/testthat/test-survival-matrix.R
@@ -46,7 +46,7 @@ test_that("survival process matrices", {
   )
   x <- bbs_matrix_survival_period(rates)
   expect_identical(dim(x), c(2L, 2L, 2L, 4L))
-  expect_identical(dim(x[, , 1, 1]), c(2L, 2L))
+  expect_identical(dim(x[,, 1, 1]), c(2L, 2L))
   expect_snapshot({
     print(x)
   })

--- a/tests/testthat/test-survival.R
+++ b/tests/testthat/test-survival.R
@@ -25,8 +25,8 @@ test_that("bbs_survival works", {
     )
 
   expect_equal(dim(x$eSurvival), c(4, 3, 2))
-  expect_true(all(x$eSurvival[, , 1] == ilogit(logit(b0_1))))
-  expect_true(all(x$eSurvival[, , 2] == ilogit(logit(b0_2))))
+  expect_true(all(x$eSurvival[,, 1] == ilogit(logit(b0_1))))
+  expect_true(all(x$eSurvival[,, 2] == ilogit(logit(b0_2))))
   expect_snapshot({
     print(x)
   })
@@ -145,9 +145,16 @@ test_that("bbs_survival_caribou works with intercepts", {
     )
 
   ex <- x$eSurvival
-  expect_true(all(unlist(ex[, , 3]) == ilogit(logit(survival_adult_female^(1 / 12)))))
-  expect_true(all(unlist(ex[, , 1]) == ilogit(logit(survival_calf_female^(1 / 12)))))
-  expect_true(all(unlist(ex[, , 2]) == ilogit(logit(survival_adult_female^(1 / 12)) + yearling_effect)))
+  expect_true(all(
+    unlist(ex[,, 3]) == ilogit(logit(survival_adult_female^(1 / 12)))
+  ))
+  expect_true(all(
+    unlist(ex[,, 1]) == ilogit(logit(survival_calf_female^(1 / 12)))
+  ))
+  expect_true(all(
+    unlist(ex[,, 2]) ==
+      ilogit(logit(survival_adult_female^(1 / 12)) + yearling_effect)
+  ))
   expect_snapshot({
     print(x)
   })
@@ -170,9 +177,16 @@ test_that("bbs_survival_caribou works with trend", {
     )
 
   ex <- x$eSurvival
-  expect_true(all(as.vector(ex[, 1, 3]) == ilogit(logit(survival_adult_female^(1 / 12)))))
-  expect_true(all(as.vector(ex[, 1, 2]) == ilogit(logit(survival_adult_female^(1 / 12)) + yearling_effect)))
-  expect_true(all(as.vector(ex[, 1, 1]) == ilogit(logit(survival_calf_female^(1 / 12)))))
+  expect_true(all(
+    as.vector(ex[, 1, 3]) == ilogit(logit(survival_adult_female^(1 / 12)))
+  ))
+  expect_true(all(
+    as.vector(ex[, 1, 2]) ==
+      ilogit(logit(survival_adult_female^(1 / 12)) + yearling_effect)
+  ))
+  expect_true(all(
+    as.vector(ex[, 1, 1]) == ilogit(logit(survival_calf_female^(1 / 12)))
+  ))
   expect_true(all(ex[1, , 1] >= ilogit(logit(survival_calf_female^(1 / 12)))))
   expect_equal(length(unique(ex[1, , 1])), nyear)
   expect_true(all(ex[1, , 3] >= ilogit(logit(survival_adult_female^(1 / 12)))))
@@ -203,7 +217,10 @@ test_that("bbs_survival_caribou works with random effects", {
     expect_equal(length(unique(ex[, 1, 3])), 1)
 
     # linear relationship logit yearling and adult
-    expect_equal(length(unique(as.vector(round(logit(ex[, , 2]) - logit(ex[, , 3]), 2)))), 1)
+    expect_equal(
+      length(unique(as.vector(round(logit(ex[,, 2]) - logit(ex[,, 3]), 2)))),
+      1
+    )
 
     expect_snapshot({
       print(x)


### PR DESCRIPTION
Closes #29

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)